### PR TITLE
Re-staking/delegating handled (I think ) the right way

### DIFF
--- a/score/liquid_icx/liquid_icx.py
+++ b/score/liquid_icx/liquid_icx.py
@@ -308,12 +308,16 @@ class LiquidICX(IconScoreBase, IRC2TokenStandard):
         Re-stake and re-delegate with the rewards claimed at the start of the cycle.
         """
         restake_value = self.getStaked() + self._rewards.get() - self._total_unstake_in_term.get()
-        self._system_score.setStake(restake_value)
         delegation: Delegation = {
             "address": PREP_ADDRESS,
             "value": restake_value
         }
-        self._system_score.setDelegation([delegation])
+        if restake_value >= self.getStaked():
+            self._system_score.setStake(restake_value)
+            self._system_score.setDelegation([delegation])
+        else:
+            self._system_score.setDelegation([delegation])
+            self._system_score.setStake(restake_value)
 
     def _endDistribution(self):
         """


### PR DESCRIPTION
Fixing staking bug.
If restake value is greater then already staked amount, contract needs to stake first and delegate, and if restaking value is less than already staked value, we need to lower delagtion and then restake with the new value.