### PR TITLE
Delegating to multiple preps when joining

### DIFF
--- a/score/liquid_icx/liquid_icx.py
+++ b/score/liquid_icx/liquid_icx.py
@@ -266,6 +266,13 @@ class LiquidICX(IconScoreBase, IRC2TokenStandard):
             self.Claim()
 
     @external
+    def vote(self) -> None:
+        """
+        External entry point to change your current vote/delegation
+        """
+        pass
+
+    @external
     def distribute(self) -> None:
         """
         Distribute I-Score rewards once per term.
@@ -337,7 +344,7 @@ class LiquidICX(IconScoreBase, IRC2TokenStandard):
         self._distributing.set(True)
 
     def _redelegate(self):
-        """vo
+        """
         Re-stake and re-delegate with the rewards claimed at the start of the cycle.
         """
         restake_value = self.getStaked() + self._rewards.get() - self._total_unstake_in_term.get()
@@ -379,7 +386,7 @@ class LiquidICX(IconScoreBase, IRC2TokenStandard):
             node_id = self._wallets.append(str(sender))
 
         current_delegations = self.getDelegation()["delegations"]
-
+        self.Debug(json_dumps(current_delegations))
         # update wallet with calling join function and stake the new amount if ICX
         wallet.join(value, delegation, (current_delegations != delegation), node_id)
         self._system_score.setStake(self.getStaked() + value)

--- a/score/liquid_icx/tests/test_integrate_base.py
+++ b/score/liquid_icx/tests/test_integrate_base.py
@@ -18,6 +18,11 @@ from iconservice.icon_constant import GOVERNANCE_ADDRESS
 
 class LICXTestBase(IconIntegrateTestBase):
 
+    # preps on yeouido test-net
+    prep_list = ["hxc60380ef4c1e76595a30fa40d7b519fb3c832db0",
+                 "hx487a43ade1479b6e7aa3d6f898a721b8ba9a4ccc",
+                 "hxec79e9c1c882632688f8c8f9a07832bcabe8be8f"]
+
     @classmethod
     def setUpClass(cls) -> None:
         super().setUpClass()

--- a/score/liquid_icx/tests/test_integrate_base.py
+++ b/score/liquid_icx/tests/test_integrate_base.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 import os
 import pprint as pp
@@ -174,10 +175,13 @@ class LICXTestBase(IconIntegrateTestBase):
     # -----------------------------------------------------------------------
     # ---------------------------- LICX methods -----------------------------
     # -----------------------------------------------------------------------
-    def _join(self, from_: KeyWallet = None, value: int = None):
+    def _join(self, from_: KeyWallet = None, value: int = None, prep_list: dict = None):
         wallet = from_ if from_ is not None else self._wallet
         value = value if value is not None else 10
-        tx = self._build_transaction(method="join", value=value * 10 ** 18, from_=wallet.get_address())
+        paras = {}
+        if prep_list is not None:
+            paras = {"delegation": json.dumps(prep_list)}
+        tx = self._build_transaction(method="join", value=value * 10 ** 18, from_=wallet.get_address(), params=paras)
         tx_result = self.process_transaction(SignedTransaction(tx, self._wallet), self._icon_service)
         return tx_result
 
@@ -269,7 +273,7 @@ class LICXTestBase(IconIntegrateTestBase):
 
     def _set_min_value_to_get_rewards(self, value, condition: bool = True):
         paras = {
-            "_value": value
+            "_value": values
         }
         tx = self._build_transaction(method="setMinValueToGetRewards", params=paras)
         tx_result = self.process_transaction(SignedTransaction(tx, self._wallet), self._icon_service)

--- a/score/liquid_icx/tests/test_integrate_liquid_icx.py
+++ b/score/liquid_icx/tests/test_integrate_liquid_icx.py
@@ -145,38 +145,34 @@ class LiquidICXTest(LICXTestBase):
         :return:
         """
         # 1
-        prep_list = ["hxc60380ef4c1e76595a30fa40d7b519fb3c832db0",
-                     "hx487a43ade1479b6e7aa3d6f898a721b8ba9a4ccc",
-                     "hxec79e9c1c882632688f8c8f9a07832bcabe8be8f"]
         delegation = {
-            prep_list[0]: 6 * 10**18,
-            prep_list[1]: 6 * 10**18,
-            prep_list[2]: 6 * 10**18
+            self.prep_list[0]: 6 * 10**18,
+            self.prep_list[1]: 6 * 10**18,
+            self.prep_list[2]: 6 * 10**18
         }
         join_tx = self._join(value=18, prep_list=delegation)
         self.assertTrue(join_tx["status"], msg=pp.pformat(join_tx))
         self.assertEqual(len(self._get_wallets()), 1)
         # check wallet
         owner = self._get_wallet()
-        pp.pprint(owner)
         self.assertEqual(int(owner["delegation_values"][0], 16), 6*10**18, msg=pp.pformat(owner))
         self.assertEqual(int(owner["delegation_values"][1], 16), 6*10**18, msg=pp.pformat(owner))
         self.assertEqual(int(owner["delegation_values"][2], 16), 6*10**18, msg=pp.pformat(owner))
-        self.assertEqual(owner["delegation_addr"][0], prep_list[0], msg=pp.pformat(owner))
-        self.assertEqual(owner["delegation_addr"][1], prep_list[1], msg=pp.pformat(owner))
-        self.assertEqual(owner["delegation_addr"][2], prep_list[2], msg=pp.pformat(owner))
+        self.assertEqual(owner["delegation_addr"][0], self.prep_list[0], msg=pp.pformat(owner))
+        self.assertEqual(owner["delegation_addr"][1], self.prep_list[1], msg=pp.pformat(owner))
+        self.assertEqual(owner["delegation_addr"][2], self.prep_list[2], msg=pp.pformat(owner))
         # check contract staking/delegating
         self.assertEqual(self._get_staked(), hex(18 * 10 ** 18), msg=pp.pformat(owner))
         self.assertEqual(self._get_delegation()["totalDelegated"], hex(18 * 10 ** 18), msg=pp.pformat(owner))
         delegations = self._get_delegation()["delegations"]
         self.assertEqual(delegations[0]["value"], hex(6 * 10 ** 18), msg=pp.pformat(owner))
-        self.assertEqual(delegations[0]["address"], prep_list[0], msg=pp.pformat(owner))
+        self.assertEqual(delegations[0]["address"], self.prep_list[0], msg=pp.pformat(owner))
         self.assertEqual(delegations[1]["value"], hex(6 * 10 ** 18), msg=pp.pformat(owner))
-        self.assertEqual(delegations[1]["address"], prep_list[1], msg=pp.pformat(owner))
+        self.assertEqual(delegations[1]["address"], self.prep_list[1], msg=pp.pformat(owner))
         self.assertEqual(delegations[2]["value"], hex(6 * 10 ** 18), msg=pp.pformat(owner))
-        self.assertEqual(delegations[2]["address"], prep_list[2], msg=pp.pformat(owner))
+        self.assertEqual(delegations[2]["address"], self.prep_list[2], msg=pp.pformat(owner))
         # 2
-        delegation = {prep_list[0]: 10 * 10 ** 18}
+        delegation = {self.prep_list[0]: 10 * 10 ** 18}
         join_tx = self._join(value=10, prep_list=delegation)
         self.assertTrue(join_tx["status"], msg=pp.pformat(join_tx))
         # check contract staking/delegating
@@ -184,17 +180,44 @@ class LiquidICXTest(LICXTestBase):
         self.assertEqual(self._get_delegation()["totalDelegated"], hex(28 * 10 ** 18), msg=pp.pformat(owner))
         delegations = self._get_delegation()["delegations"]
         self.assertEqual(delegations[0]["value"], hex(16 * 10 ** 18), msg=pp.pformat(owner))
-        self.assertEqual(delegations[0]["address"], prep_list[0], msg=pp.pformat(owner))
+        self.assertEqual(delegations[0]["address"], self.prep_list[0], msg=pp.pformat(owner))
         self.assertEqual(delegations[1]["value"], hex(6 * 10 ** 18), msg=pp.pformat(owner))
-        self.assertEqual(delegations[1]["address"], prep_list[1], msg=pp.pformat(owner))
+        self.assertEqual(delegations[1]["address"], self.prep_list[1], msg=pp.pformat(owner))
         self.assertEqual(delegations[2]["value"], hex(6 * 10 ** 18), msg=pp.pformat(owner))
-        self.assertEqual(delegations[2]["address"], prep_list[2], msg=pp.pformat(owner))
+        self.assertEqual(delegations[2]["address"], self.prep_list[2], msg=pp.pformat(owner))
 
 
 
-        # TODO
         # 1. Write test-case, where user does not vote at first, and then votes at next join
 
+    def test_5(self):
+        """
+
+        """
+        # 1
+        delegation = {
+            self.prep_list[0]: 10 * 10**18,
+        }
+        # Fails
+        join_tx = self._join(value=18, prep_list=delegation)
+        self.assertFalse(join_tx["status"], msg=pp.pformat(join_tx))
+        self.assertIn("Delegations values do not match", join_tx["failure"]["message"], msg=pp.pformat(join_tx))
+        # Success
+        join_tx = self._join(value=10, prep_list=delegation)
+        self.assertTrue(join_tx["status"], msg=pp.pformat(join_tx))
+        delegations = self._get_delegation()["delegations"]
+        self.assertEqual(delegations[0]["value"], hex(10 * 10 ** 18), msg=pp.pformat(delegations))
+        self.assertEqual(delegations[0]["address"], self.prep_list[0], msg=pp.pformat(delegations))
+        # 2
+        transfer_tx = self._transfer_icx_from_to(self._wallet, self._wallet2, 50)
+        self.assertTrue(join_tx["status"], msg=pp.pformat(transfer_tx))
+        join_tx = self._join(value=10)
+        pp.pprint(join_tx)
+        self.assertTrue(join_tx["status"], msg=pp.pformat(join_tx))
+        self.assertEqual(self._get_staked(), hex(20 * 10 ** 18), msg=pp.pformat(self._get_staked()))
+        delegations = self._get_delegation()["delegations"]
+        self.assertEqual(delegations[0]["value"], hex(20 * 10 ** 18), msg=pp.pformat(delegations))
+        self.assertEqual(delegations[0]["address"], self.prep_list[0], msg=pp.pformat(delegations))
 
 
 

--- a/score/liquid_icx/tests/test_integrate_liquid_icx.py
+++ b/score/liquid_icx/tests/test_integrate_liquid_icx.py
@@ -11,7 +11,7 @@ from score.liquid_icx.tests.test_integrate_base import LICXTestBase
 
 class LiquidICXTest(LICXTestBase):
 
-    LOCAL_NETWORK_TEST = False
+    LOCAL_NETWORK_TEST = True
 
     def setUp(self, **kwargs):
         super().setUp()
@@ -158,6 +158,7 @@ class LiquidICXTest(LICXTestBase):
         self.assertEqual(len(self._get_wallets()), 1)
         # check wallet
         owner = self._get_wallet()
+        pp.pprint(owner)
         self.assertEqual(int(owner["delegation_values"][0], 16), 6*10**18, msg=pp.pformat(owner))
         self.assertEqual(int(owner["delegation_values"][1], 16), 6*10**18, msg=pp.pformat(owner))
         self.assertEqual(int(owner["delegation_values"][2], 16), 6*10**18, msg=pp.pformat(owner))
@@ -188,6 +189,11 @@ class LiquidICXTest(LICXTestBase):
         self.assertEqual(delegations[1]["address"], prep_list[1], msg=pp.pformat(owner))
         self.assertEqual(delegations[2]["value"], hex(6 * 10 ** 18), msg=pp.pformat(owner))
         self.assertEqual(delegations[2]["address"], prep_list[2], msg=pp.pformat(owner))
+
+
+
+        # TODO
+        # 1. Write test-case, where user does not vote at first, and then votes at next join
 
 
 

--- a/score/liquid_icx/wallet.py
+++ b/score/liquid_icx/wallet.py
@@ -21,8 +21,8 @@ class Wallet:
         self._node_id = VarDB("wallet_id_" + str(_address), db, value_type=int)
 
         # Tracking individual wallet's delegations
-        self._voting = VarDB("voting_" + str(_address), db, value_type=int)
-        self._delegation_addr = ArrayDB("delegation_addr_" + str(_address), db, value_type=str)
+        # self._voting = VarDB("voting_" + str(_address), db, value_type=int)
+        self._delegation_address = ArrayDB("delegation_addr_" + str(_address), db, value_type=str)
         self._delegation_value = ArrayDB("delegation_value_" + str(_address), db, value_type=int)
         # self._delegation_bps = ArrayDB("delegation_bps_" + str(_address), db, value_type=int)
 
@@ -50,18 +50,16 @@ class Wallet:
         if voting:
             delegation_amount_sum = 0
             for addr, value in delegation.items():
-                if addr not in self._delegation_addr:
-                    self._delegation_addr.put(addr)
+                if addr not in self._delegation_address:
+                    self._delegation_address.put(addr)
                     self._delegation_value.put(value)
                 else:
-                    index = list(self._delegation_addr).index(addr)
+                    index = list(self._delegation_address).index(addr)
                     self._delegation_value[index] += value
                 delegation_amount_sum += value
 
             if delegation_amount_sum != join_amount:
                 revert(f"LiquidICX: Delegations values do not match to the amount of ICX sent. {delegation_amount_sum} : {join_amount}")
-
-            self.voting = 1
 
     def requestLeave(self, _leave_amount):
         """
@@ -172,17 +170,17 @@ class Wallet:
     def node_id(self, value):
         self._node_id.set(value)
 
-    @property
-    def voting(self):
-        return self._voting.get()
+    # @property
+    # def voting(self):
+    #     return self._voting.get()
+    #
+    # @voting.setter
+    # def voting(self, voting: int):
+    #     self._voting.set(voting)
 
-    @voting.setter
-    def voting(self, voting: int):
-        self._voting.set(voting)
-
     @property
-    def delegation_addr(self):
-        return self._delegation_addr
+    def delegation_address(self):
+        return self._delegation_address
 
     @property
     def delegation_value(self):
@@ -200,8 +198,8 @@ class Wallet:
             "unstaking": self.unstaking,
             "leave_values": list(self.leave_values),
             "unstake_heights": list(self.unstake_heights),
-            "voting": self.voting,
-            "delegation_addr": list(self.delegation_addr),
+            # "voting": self.voting,
+            "delegation_addr": list(self.delegation_address),
             "delegation_values": list(self._delegation_value),
             # "delegation_bps": list(self._delegation_bps)
         }


### PR DESCRIPTION
## Description
Add voting functionality to the LICX. 
When user is joining, he can pass additional information to which prep or group of preps he wants to delegate.
This information will be then stored in his wallet, and the new (updated) delegation will be set.

I opened this PR, so we can have an open discussion about the current implementation and flaws that might be in there.

## Improvements

Voting was the essential part, that was still missing in LICX. This PR starts to working on that.

## How Has This Been Tested?

Implemented an integrate test.

## Checklist:
If you have any comments regarding one of these points just write it down.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes